### PR TITLE
Feature: Module

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.1",
   "description": "vanilla javascript input mask",
   "main": "dist/imask.js",
+  "module": "src/imask.js",
   "dependencies": {},
   "devDependencies": {
     "babel-core": "^6.26.0",
@@ -60,6 +61,10 @@
     "jquery",
     "input",
     "mask"
+  ],
+  "files": [
+    "dist",
+    "src"
   ],
   "author": "Alexey Kryazhev",
   "license": "MIT",


### PR DESCRIPTION
Add module entry to package.json.
This way webpack or rollup can use the ES6 module instead of the transpiled ES5 version from babel which includes a lot of shimed code.
If module import is supported the `src/imask.js` file gets imported otherwise it falls back to `dist/imask.js` when using `require`.
This will save quite a few bytes in the final bundle.

See: https://github.com/rollup/rollup/wiki/pkg.module