### PR TITLE
Update README.md

### DIFF
--- a/packages/react-imask/README.md
+++ b/packages/react-imask/README.md
@@ -42,7 +42,7 @@ const StyledInput = styled.input`
 const MaskedStyledInput = IMaskMixin(({inputRef, ...props}) => (
   <StyledInput
     ...props
-    innerRef={inputRef}  // bind internal input
+    innerRef={inputRef}  // bind internal input (if you use styled-components V4, use "ref" instead "innerRef")
   />
 ));
 


### PR DESCRIPTION
https://www.styled-components.com/releases?#v4.0.0
Migrate to use new React.forwardRef API, by @probablyup; note that this **removes the innerRef** API since it is no longer needed.