### PR TITLE
Fix JSX syntax in readme

### DIFF
--- a/packages/react-imask/README.md
+++ b/packages/react-imask/README.md
@@ -41,7 +41,7 @@ const StyledInput = styled.input`
 
 const MaskedStyledInput = IMaskMixin(({inputRef, ...props}) => (
   <StyledInput
-    ...props
+    {...props}
     innerRef={inputRef}  // bind internal input (if you use styled-components V4, use "ref" instead "innerRef")
   />
 ));


### PR DESCRIPTION
According to [docs](https://reactjs.org/docs/jsx-in-depth.html#spread-attributes)