### PR TITLE
Ability to Focus and Blur the input element

### DIFF
--- a/packages/vue-imask/src/imask.component.js
+++ b/packages/vue-imask/src/imask.component.js
@@ -11,6 +11,7 @@ const IMaskComponent = {
         value: this.maskRef ? this.maskRef.value : this.value
       },
       on: {...this.$listeners},
+      ref: 'input',
     };
 
     // if there is no mask use default input event
@@ -119,6 +120,14 @@ const IMaskComponent = {
         this.maskRef.destroy();
         delete this.maskRef;
       }
+    },
+    
+    focus () {
+      this.$refs.input.focus();
+    },
+    
+    blur () {
+      this.$refs.input.blur();
     }
   },
 


### PR DESCRIPTION
This adds the ability to trigger focus and blur events on the inner input when the `imask-input` has a ref i.e
```
<imask-input ref="myMask" mask"..." />

...

export default {
   ...
   methods: {
      focusOnMask(){
         this.$refs.myMask.focus();
      }
   }
}
```