### PR TITLE
Add compatibility with web components

### DIFF
--- a/packages/imask/package-lock.json
+++ b/packages/imask/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "imask",
-	"version": "5.1.6",
+	"version": "5.2.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/imask/package-lock.json
+++ b/packages/imask/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "imask",
-	"version": "5.2.1",
+	"version": "5.1.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/imask/src/controls/html-mask-element.js
+++ b/packages/imask/src/controls/html-mask-element.js
@@ -25,7 +25,12 @@ class HTMLMaskElement extends MaskElement {
     @readonly
   */
   get isActive (): boolean {
-    return this.input === document.activeElement;
+    const rootElement = this.input.getRootNode
+      ? this.input.getRootNode()
+      : document;
+
+    //$FlowFixMe
+    return this.input === rootElement.activeElement;
   }
 
   /**

--- a/packages/imask/test/controls/html-mask-element.js
+++ b/packages/imask/test/controls/html-mask-element.js
@@ -1,0 +1,33 @@
+import { assert } from 'chai';
+
+import HTMLMaskElement from '../../src/controls/html-mask-element';
+
+
+describe('HTMLMaskElement', function () {
+  describe('#get isActive', function () {
+    it('should use getRootNode if available', function () {
+      const input = {
+        getRootNode () {
+          return this;
+        },
+        get activeElement () {
+          return this;
+        }
+      };
+
+      const maskElement = new HTMLMaskElement(input);
+      assert.strictEqual(maskElement.isActive, true);
+    });
+
+    it('should use document as a fallback', function () {
+      const doc = global.document;
+
+      const input = {};
+      global.document = { activeElement: input };
+      const maskElement = new HTMLMaskElement(input);
+      assert.strictEqual(maskElement.isActive, true);
+
+      global.document = doc;
+    });
+  });
+});


### PR DESCRIPTION
## Description

Imaskjs breaks when used inside web components.

![iMask Bug](https://user-images.githubusercontent.com/125764/70200772-52309100-16f3-11ea-8195-8b1b1bf1564f.gif)

This happens because Imaskjs relies on `document.activeElement` to detect if an input element is active, but if it is inside a shadowDOM (i.e. inside a web component) a false negative is returned.

This PR solves the problem by using `this.input.getRootNode` instead of `document`, with a fallback to `document` for browsers that do not support it.