### PR TITLE
Remove unnecessary warning

### DIFF
--- a/packages/imask/src/masked/factory.js
+++ b/packages/imask/src/masked/factory.js
@@ -27,7 +27,16 @@ function maskedClass (mask: Mask): Class<Masked<*>> {
   // $FlowFixMe
   if (mask instanceof Function) return IMask.MaskedFunction;
 
-  console.warn('Mask not found for mask', mask);  // eslint-disable-line no-console
+  if (!(mask instanceof IMask.MaskedRegExp) 
+    && !(mask instanceof IMask.MaskedPattern) 
+    && !(mask instanceof IMask.MaskedDate) 
+    && !(mask instanceof IMask.MaskedNumber) 
+    && !(mask instanceof IMask.MaskedDynamic) 
+    && !(mask instanceof IMask.Masked) 
+    && !(mask instanceof IMask.MaskedFunction)) {
+    console.warn('Mask not found for mask', mask);  // eslint-disable-line no-console
+  }
+  
   // $FlowFixMe
   return IMask.Masked;
 }

--- a/packages/imask/test/controls/input.js
+++ b/packages/imask/test/controls/input.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 
-import IMask, { InputMask } from '../../src';
+import IMask, { InputMask, createMask } from '../../src';
 import MaskElementStub from './mask-element-stub';
 
 
@@ -37,7 +37,12 @@ describe('InputMask', function () {
     });
 
     it('should set new mask', function () {
-      [Date, Number, 'string', /regexp/, function () {}, Date].forEach(mask => {
+      const opts = {
+        mask: Number,
+        max: 100
+      };
+
+      [Date, Number, 'string', /regexp/, function () {}, Date, createMask(opts)].forEach(mask => {
         let oldMask = imask.mask;
         let oldMasked = imask.masked;
 


### PR DESCRIPTION
Once createMask has been called, subsequent calls to maskedClass result in unnecessary warnings. 