### PR TITLE
Allow tree shaking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4862,6 +4862,15 @@
 			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
 			"dev": true
 		},
+		"@types/fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-UoOfVEzAUpeSPmjm7h1uk5MH6KZma2z2O7a75onTGjnNvAvMVrPzPL/vBbT65iIGHWj6rokwfmYcmxmlSf2uwg==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/glob": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
@@ -6305,6 +6314,12 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"colorette": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.1.0.tgz",
+			"integrity": "sha512-6S062WDQUXi6hOfkO/sBPVwE5ASXY4G2+b4atvhJfSsuUUhIaUKlkjLe9692Ipyt5/a+IPF5aVTu3V5gvXq5cg==",
 			"dev": true
 		},
 		"columnify": {
@@ -10708,6 +10723,12 @@
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true
 		},
+		"isobject": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+			"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+			"dev": true
+		},
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -11712,6 +11733,16 @@
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
 			"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
 			"dev": true
+		},
+		"micromatch": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+			"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+			"dev": true,
+			"requires": {
+				"braces": "^3.0.1",
+				"picomatch": "^2.0.5"
+			}
 		},
 		"mime": {
 			"version": "2.4.4",
@@ -14355,6 +14386,105 @@
 					"requires": {
 						"path-parse": "^1.0.6"
 					}
+				}
+			}
+		},
+		"rollup-plugin-copy": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-copy/-/rollup-plugin-copy-3.3.0.tgz",
+			"integrity": "sha512-euDjCUSBXZa06nqnwCNADbkAcYDfzwowfZQkto9K/TFhiH+QG7I4PUsEMwM9tDgomGWJc//z7KLW8t+tZwxADA==",
+			"dev": true,
+			"requires": {
+				"@types/fs-extra": "^8.0.1",
+				"colorette": "^1.1.0",
+				"fs-extra": "^8.1.0",
+				"globby": "10.0.1",
+				"is-plain-object": "^3.0.0"
+			},
+			"dependencies": {
+				"@nodelib/fs.stat": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+					"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+					"dev": true
+				},
+				"array-union": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+					"dev": true
+				},
+				"dir-glob": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+					"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+					"dev": true,
+					"requires": {
+						"path-type": "^4.0.0"
+					}
+				},
+				"fast-glob": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
+					"integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
+					"dev": true,
+					"requires": {
+						"@nodelib/fs.stat": "^2.0.2",
+						"@nodelib/fs.walk": "^1.2.3",
+						"glob-parent": "^5.1.0",
+						"merge2": "^1.3.0",
+						"micromatch": "^4.0.2",
+						"picomatch": "^2.2.1"
+					}
+				},
+				"globby": {
+					"version": "10.0.1",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
+					"integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
+					"dev": true,
+					"requires": {
+						"@types/glob": "^7.1.1",
+						"array-union": "^2.1.0",
+						"dir-glob": "^3.0.1",
+						"fast-glob": "^3.0.3",
+						"glob": "^7.1.3",
+						"ignore": "^5.1.1",
+						"merge2": "^1.2.3",
+						"slash": "^3.0.0"
+					}
+				},
+				"ignore": {
+					"version": "5.1.4",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+					"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+					"dev": true
+				},
+				"is-plain-object": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+					"integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+					"dev": true,
+					"requires": {
+						"isobject": "^4.0.0"
+					}
+				},
+				"path-type": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+					"dev": true
+				},
+				"picomatch": {
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+					"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+					"dev": true
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+					"dev": true
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "rollup": "^1.31.1",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.1.0",
+    "rollup-plugin-copy": "^3.3.0",
     "rollup-plugin-eslint": "^7.0.0",
     "rollup-plugin-multi-input": "^1.0.3",
     "rollup-plugin-node-resolve": "^5.2.0",

--- a/packages/angular-imask/example/app/app.component.ts
+++ b/packages/angular-imask/example/app/app.component.ts
@@ -6,8 +6,8 @@ import { Component } from '@angular/core';
     <input
       [imask]="{mask: '+{7}(000)000-00-00'}"
       [unmask]="true"
-      (accept)="onAccept($event)"
-      (complete)="onAccept($event)"
+      (accept)="onAccept()"
+      (complete)="onAccept()"
     />
   `,
   styles: []

--- a/packages/angular-imask/example/app/app.module.ts
+++ b/packages/angular-imask/example/app/app.module.ts
@@ -2,7 +2,8 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 
 import { AppComponent } from './app.component';
-import { IMaskModule } from 'angular-imask';
+import { IMaskDirectiveModule, IMaskFactory } from 'angular-imask';
+import { NumberIMaskFactory } from './number-imask-factory';
 
 @NgModule({
   declarations: [
@@ -10,9 +11,11 @@ import { IMaskModule } from 'angular-imask';
   ],
   imports: [
     BrowserModule,
-    IMaskModule
+    IMaskDirectiveModule,
   ],
-  providers: [],
+  providers: [
+    {provide: IMaskFactory, useClass: NumberIMaskFactory} // it's optional
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/packages/angular-imask/example/app/number-imask-factory.ts
+++ b/packages/angular-imask/example/app/number-imask-factory.ts
@@ -1,0 +1,13 @@
+import IMask from 'imask/esm/imask';
+// add needed features
+import 'imask/esm/masked/number';
+import { IMaskFactory } from "angular-imask";
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class NumberIMaskFactory extends IMaskFactory{
+    create<Opts extends IMask.AnyMaskedOptions>(
+        el: IMask.HTMLMaskingElement | IMask.MaskElement, opts: Opts): IMask.InputMask<Opts> {
+        return IMask(el, opts);
+    }
+}

--- a/packages/angular-imask/example/main.ts
+++ b/packages/angular-imask/example/main.ts
@@ -3,6 +3,7 @@ import { enableProdMode } from '@angular/core';
 
 import { AppModule } from './app/app.module';
 
+enableProdMode();
 
 platformBrowserDynamic().bootstrapModule(AppModule)
   .catch(err => console.error(err));

--- a/packages/angular-imask/package.json
+++ b/packages/angular-imask/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "ng-packagr --config tsconfig.json",
     "dev": "ng build angular-imask --watch",
-    "example": "ng serve"
+    "example": "ng serve --aot"
   },
   "keywords": [
     "angular",

--- a/packages/angular-imask/src/default-imask-factory.ts
+++ b/packages/angular-imask/src/default-imask-factory.ts
@@ -1,0 +1,10 @@
+import { IMaskFactory } from "./imask-factory";
+import IMask from 'imask';
+import { Injectable } from "@angular/core";
+
+@Injectable({providedIn: 'root'})
+export class DefaultImaskFactory implements IMaskFactory {
+    create<Opts extends IMask.AnyMaskedOptions>(el: IMask.MaskElement | IMask.HTMLMaskingElement, opts: Opts) {
+        return IMask(el, opts);
+    }
+}

--- a/packages/angular-imask/src/directive.module.ts
+++ b/packages/angular-imask/src/directive.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { IMaskDirective } from './imask.directive';
+import { IMaskFactory } from './imask-factory';
+import { DefaultImaskFactory } from './default-imask-factory';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [IMaskDirective],
+  providers: [{provide: IMaskFactory, useClass: DefaultImaskFactory}],
+  exports: [IMaskDirective]
+})
+export class IMaskDirectiveModule {}

--- a/packages/angular-imask/src/imask-factory.ts
+++ b/packages/angular-imask/src/imask-factory.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+
+type AnyMaskedOptions = import('imask').default.AnyMaskedOptions;
+type HTMLMaskingElement = import('imask').default.HTMLMaskingElement;
+type MaskElement = import('imask').default.MaskElement;
+type InputMask<T> = import('imask').default.InputMask<T>;
+
+@Injectable({providedIn: "root"})
+export abstract class IMaskFactory {
+    abstract create<Opts extends AnyMaskedOptions>(el: MaskElement | HTMLMaskingElement, opts: Opts): InputMask<Opts>
+}

--- a/packages/angular-imask/src/imask.directive.ts
+++ b/packages/angular-imask/src/imask.directive.ts
@@ -5,9 +5,7 @@ import {
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor, COMPOSITION_BUFFER_MODE } from '@angular/forms';
 
-// TODO import only types when ts 3.8 released or when move IMask to ts
-import IMask from 'imask';
-
+import {IMaskFactory} from "./imask-factory";
 
 export const MASKEDINPUT_VALUE_ACCESSOR: Provider = {
   provide: NG_VALUE_ACCESSOR,
@@ -26,7 +24,7 @@ const DEFAULT_IMASK_ELEMENT = (elementRef: any) => elementRef.nativeElement;
   },
   providers: [MASKEDINPUT_VALUE_ACCESSOR]
 })
-export class IMaskDirective<Opts extends IMask.AnyMaskedOptions> implements ControlValueAccessor, AfterViewInit, OnDestroy, OnChanges {
+export class IMaskDirective<Opts extends import('imask').default.AnyMaskedOptions> implements ControlValueAccessor, AfterViewInit, OnDestroy, OnChanges {
   maskRef?: IMask.InputMask<Opts>;
   onTouched: any;
   onChange: any;
@@ -43,6 +41,7 @@ export class IMaskDirective<Opts extends IMask.AnyMaskedOptions> implements Cont
 
   constructor(private _elementRef: ElementRef,
               private _renderer: Renderer2,
+              private _factory: IMaskFactory,
               @Optional() @Inject(COMPOSITION_BUFFER_MODE) private _compositionMode: boolean) {
     // init here to support AOT (TODO may be will work with ng-packgr - need to check)
     this.onTouched = () => {};
@@ -159,7 +158,7 @@ export class IMaskDirective<Opts extends IMask.AnyMaskedOptions> implements Cont
   }
 
   private initMask () {
-    this.maskRef = IMask(this.element, this.imask as Opts)
+    this.maskRef = this._factory.create(this.element, this.imask as Opts)
       .on('accept', this._onAccept.bind(this))
       .on('complete', this._onComplete.bind(this));
   }

--- a/packages/angular-imask/src/imask.directive.ts
+++ b/packages/angular-imask/src/imask.directive.ts
@@ -4,15 +4,9 @@ import {
   Optional, Inject, SimpleChanges,
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor, COMPOSITION_BUFFER_MODE } from '@angular/forms';
-import { ɵgetDOM as getDOM } from '@angular/platform-browser';
+
 // TODO import only types when ts 3.8 released or when move IMask to ts
 import IMask from 'imask';
-
-
-function _isAndroid(): boolean {
-  const userAgent = getDOM() ? getDOM().getUserAgent() : '';
-  return /android (\d+)/.test(userAgent.toLowerCase());
-}
 
 
 export const MASKEDINPUT_VALUE_ACCESSOR: Provider = {
@@ -61,7 +55,7 @@ export class IMaskDirective<Opts extends IMask.AnyMaskedOptions> implements Cont
     this._writing = false;
 
     if (this._compositionMode == null) {
-      this._compositionMode = !_isAndroid();
+      this._compositionMode = !this._isAndroid();
     }
   }
 
@@ -191,5 +185,9 @@ export class IMaskDirective<Opts extends IMask.AnyMaskedOptions> implements Cont
   _compositionEnd(value: any): void {
     this._composing = false;
     this._compositionMode && this._handleInput(value);
+  }
+
+  private _isAndroid(): boolean {
+    return /android (\d+)/.test(navigator.userAgent.toLowerCase());
   }
 }

--- a/packages/angular-imask/src/imask.module.ts
+++ b/packages/angular-imask/src/imask.module.ts
@@ -1,13 +1,12 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
-import { IMaskDirective } from './imask.directive';
 import { IMaskPipe } from './imask.pipe';
-
+import { IMaskDirectiveModule } from './directive.module';
 
 @NgModule({
-  imports: [CommonModule],
-  declarations: [IMaskDirective, IMaskPipe],
-  exports: [IMaskDirective, IMaskPipe]
+  imports: [CommonModule, IMaskDirectiveModule],
+  declarations: [IMaskPipe],
+  exports: [IMaskPipe, IMaskDirectiveModule]
 })
 export class IMaskModule {}

--- a/packages/angular-imask/src/index.ts
+++ b/packages/angular-imask/src/index.ts
@@ -1,3 +1,5 @@
 export * from './imask.directive';
 export * from './imask.pipe';
 export * from './imask.module';
+export * from './imask-factory';
+export * from './directive.module';

--- a/packages/angular-imask/tsconfig.example.json
+++ b/packages/angular-imask/tsconfig.example.json
@@ -10,5 +10,9 @@
   ],
   "include": [
     "src/**/*.ts"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "fullTemplateTypeCheck": true,
+    "strictInjectionParameters": true
+  }
 }

--- a/packages/angular-imask/tsconfig.json
+++ b/packages/angular-imask/tsconfig.json
@@ -12,7 +12,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,
-    "baseUrl": ".",
+    "baseUrl": "./",
     "paths": {
       "@angular/*": ["node_modules/@angular/*"],
       "rxjs/*": ["node_modules/rxjs/*"],

--- a/packages/imask/rollup.config.js
+++ b/packages/imask/rollup.config.js
@@ -5,7 +5,7 @@ import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import polyfill from 'rollup-plugin-polyfill';
 import multiInput from 'rollup-plugin-multi-input';
-
+import copy from 'rollup-plugin-copy'
 
 const commonPlugins = [
   resolve(),
@@ -41,6 +41,11 @@ export default [
     plugins: [
       multiInput(),
       ...commonPlugins,
+      copy({
+        targets: [
+          { src: 'index.d.ts', dest: 'esm', rename: 'imask.d.ts' },
+        ]
+      })
     ]
   }
 ];


### PR DESCRIPTION
It’d be nice to make tree shaking working with angular plugin.
Removed the import of imask js from the directive. As to make the plugin backward compatible, I added DefaultImaskFactory.

Thanks to [tree-shakable providers](https://angular.io/guide/dependency-injection-providers#tree-shakable-providers) DefaultImaskFactory is not included in the final build if there is another module that provides IMaskFactory.

However, at the moment all modules from imask are still included. One can reproduce this by doing following:
1. Install deps
2. `npm run make`
3. `cd packages/angular-imask`
4. `ng serve --aot --prod`
I expect that only esm/imask and esm/number will be included, but all the files from esm/index are included.

I have a couple of hypotheses why this happens:
- Angular compiler includes esm/index, because of 'packages/angular-imask/src/index.ts'. For example, imask.pipe.ts imports esm/index file.
- Probably there are wrong imports somewhere else.

@uNmAnNeR any thoughts on the problem?