### PR TITLE
added reassign for event handlers if they get updated from outside

### DIFF
--- a/packages/react-imask/src/hook.ts
+++ b/packages/react-imask/src/hook.ts
@@ -5,23 +5,23 @@ import type { ReactMaskProps, MaskedElement, Falsy } from './mixin';
 
 
 export default
-  function useIMask<
-    Opts extends IMask.AnyMaskedOptions = IMask.AnyMaskedOptions,
-    Unmask extends ('typed' | boolean) = false,
-    Value = Unmask extends 'typed' ? IMask.InputMask<Opts>['typedValue'] :
-    Unmask extends Falsy ? IMask.InputMask<Opts>['value'] :
-    IMask.InputMask<Opts>['unmaskedValue']
-  >(
-    opts: Opts,
-    { onAccept, onComplete }: Pick<ReactMaskProps<Opts, Unmask, Value>, 'onAccept' | 'onComplete'> = {}
-  ): {
-    ref: MutableRefObject<MaskedElement>,
-    maskRef: MutableRefObject<IMask.InputMask<Opts>>,
-  } {
+function useIMask<
+  Opts extends IMask.AnyMaskedOptions = IMask.AnyMaskedOptions,
+  Unmask extends ('typed' | boolean) = false,
+  Value = Unmask extends 'typed' ? IMask.InputMask<Opts>['typedValue'] :
+  Unmask extends Falsy ? IMask.InputMask<Opts>['value'] :
+  IMask.InputMask<Opts>['unmaskedValue']
+>(
+  opts: Opts,
+  { onAccept, onComplete }: Pick<ReactMaskProps<Opts, Unmask, Value>, 'onAccept' | 'onComplete'> = {}
+): {
+  ref: MutableRefObject<MaskedElement>,
+  maskRef: MutableRefObject<IMask.InputMask<Opts>>,
+} {
   const ref = useRef(null);
   const maskRef = useRef(null);
 
-  const deleteMask = useCallback(() => {
+  const destroyMask = useCallback(() => {
     maskRef.current?.destroy();
     maskRef.current = null;
   }, []);
@@ -39,7 +39,7 @@ export default
   useEffect(() => {
     const el = ref.current;
 
-    if (!el || !opts?.mask) return deleteMask();
+    if (!el || !opts?.mask) return destroyMask();
 
     const mask = maskRef.current;
 
@@ -52,7 +52,7 @@ export default
     } else {
       mask?.updateOptions(opts);
     }
-  }, [opts, deleteMask, handleOnAccept]);
+  }, [opts, destroyMask, handleOnAccept]);
 
   useEffect(() => {
     if (!maskRef.current) return;
@@ -68,7 +68,7 @@ export default
     };
   }, [handleOnAccept, handleOnComplete]);
 
-  useEffect(() => deleteMask, [deleteMask]);
+  useEffect(() => destroyMask, [destroyMask]);
 
   return {
     ref,


### PR DESCRIPTION
Это снова я) В текущем варианте хука обработчики `onAccept` и `onComplete` назначаются один раз, во время вызова `_initMask`. Если функции передаваемые в хук извне поменяются, то маска это проигнорирует, т.к. событие будет обрабатываться тем обработчиком, который пришел на момент инициализации маски.

Я добавил логику которая переподписывает обработчики событий если они поменялись во внешнем коде + отрефакторил код хука, с правильно раставленными deps array, чтобы код корректно реагировал на изменение пропсов или внутреннего состояния.