### PR TITLE
Fix Firefox masked behavior for wrapped inputs (e.g. Vuetify)

### DIFF
--- a/packages/imask/src/controls/html-mask-element.js
+++ b/packages/imask/src/controls/html-mask-element.js
@@ -94,12 +94,24 @@ class HTMLMaskElement extends MaskElement {
   /** */
   _toggleEventHandler (event: string, handler?: Function): void {
     if (this._handlers[event]) {
-      this.input.removeEventListener(event, this._handlers[event]);
+      if (event === 'input' && this.input.parentElement) {
+        // remove input event from parent instead
+        this.input.parentElement.removeEventListener(event, this._handlers[event], true);
+      } else {
+        // default behaviour
+        this.input.removeEventListener(event, this._handlers[event]);
+      }
       delete this._handlers[event];
     }
 
     if (handler) {
-      this.input.addEventListener(event, handler);
+      if (event === 'input' && this.input.parentElement) {
+        // add input event to parent instead to fix mask behaviour in firefox when input is inside a wrapper
+        this.input.parentElement.addEventListener(event, handler, true);
+      } else {
+        // default behaviour
+        this.input.addEventListener(event, handler);
+      }
       this._handlers[event] = handler;
     }
   }


### PR DESCRIPTION
# The problem
This patch makes the library compatible with wrapped input, specifically Vuetify.
When one tried to the library on a Vuetify `V-Input` component:

```vue
<template>
  <v-text-field ref="input" ... />
</template>
```

The mask can be applied to the wrapped input with:
```js
const input = `this.$refs['input'].$el.querySelector('input')`;
const mask = IMask(input, { mask: '00:00' });
```

This works completely fine in Chromium and Webkit, however on Firefox, the input events are fired in another order, which causes the mask field the be out of sync with the actual input value. One cause is, for example, that placeholders are shifted instead of being replaced.

# The fix
I found a solution to the problem [here](https://github.com/RonaldJerez/vue-input-facade/pull/32). The exact problem is explained there.

Basically, the only thing I changed is, that `input` event listeners are not added to the element directly, but rather to the parent.
Parent elements do also receive the input elements, but before the actual input does.
In the case of Vuetify, this is crucial, because they have their own listeners (which are causing the de-sync) on the input element directly. I also made these listeners capturing, so that they are executed first (hopefully).

That seems to work quite well, as far as I have tested. Side-effects don't seem to appear at the moment, since the event target (the parent) is not referenced inside the event listener, but rather the input element directly (`this.input`).