### PR TITLE
fix contentEditable selection calculations

### DIFF
--- a/packages/imask/src/controls/html-contenteditable-mask-element.js
+++ b/packages/imask/src/controls/html-contenteditable-mask-element.js
@@ -12,7 +12,12 @@ class HTMLContenteditableMaskElement extends HTMLMaskElement {
   get _unsafeSelectionStart (): number {
     const root = this.rootElement;
     const selection = root.getSelection && root.getSelection();
-    return selection && selection.anchorOffset;
+    const anchorOffset = selection && selection.anchorOffset;
+    const focusOffset = selection && selection.focusOffset;
+    if (focusOffset == null || anchorOffset == null || anchorOffset < focusOffset) {
+      return anchorOffset;
+    }
+    return focusOffset;
   }
 
   /**
@@ -22,7 +27,12 @@ class HTMLContenteditableMaskElement extends HTMLMaskElement {
   get _unsafeSelectionEnd (): number {
     const root = this.rootElement;
     const selection = root.getSelection && root.getSelection();
-    return selection && (this._unsafeSelectionStart + String(selection).length);
+    const anchorOffset = selection && selection.anchorOffset;
+    const focusOffset = selection && selection.focusOffset;
+    if (focusOffset == null || anchorOffset == null || anchorOffset > focusOffset) {
+      return anchorOffset;
+    }
+    return focusOffset;
   }
 
   /**


### PR DESCRIPTION
# Problem
Bug behavior when selecting text backwards in contentEditable and backspace it.

## Bug
Bug is in selection calculations for contentEditable.
It doesn't consider that the selection can direct backwards.
It only calculates forward direction selection.

## Solution
Do comparison between anchorOffset and focusOffset.
Bigger offset is selectionEnd, smaller one is selectionStart.

## Demo to reproduce
https://codesandbox.io/s/lucid-villani-q54wt?file=/src/index.tsx