### PR TITLE
fix(vue-imask): Add initial typescript definition file for vue-imask

### DIFF
--- a/packages/vue-imask/index.d.ts
+++ b/packages/vue-imask/index.d.ts
@@ -1,0 +1,32 @@
+import {Ref} from "vue";
+
+export {IMask} from 'imask';
+export const IMaskComponent: any;
+export const IMaskDirective: any;
+
+/**
+ * We allow the user to provide the props of the component, which we watch in case it contains a mask definition,
+ * To see what props are accepted see props.js
+ */
+type AcceptedProps = {mask: {}, [key: string]: any}
+
+export declare function useIMask(
+	props: AcceptedProps | Ref<AcceptedProps>,
+	{
+		emit,
+		onAccept,
+		onComplete,
+	}?: {
+		emit?: (eventName: string, val: any)=>void;
+		onAccept?: ()=>void;
+		onComplete?: ()=>void;
+	}
+): {
+	el: Ref<HTMLInputElement>;
+	mask: Readonly<Ref<{ typedValue: string, unmaskedValue: string, value: string }>>;
+	masked: Ref<string>;
+	unmasked: Ref<string>;
+	typed: Ref<string>;
+};
+
+export const IMaskProps: any;

--- a/packages/vue-imask/package.json
+++ b/packages/vue-imask/package.json
@@ -39,5 +39,6 @@
   "gitHead": "228f2a4dce7125d0c7156868fcb5364b4487c8e6",
   "devDependencies": {
     "vue": "^2.6.14"
-  }
+  },
+  "types": "index.d.ts"
 }


### PR DESCRIPTION
Currently only useIMask has real type safety, all other exports are given explicit 'any' until their types can be determined.

I'm unsure what if any contribution guidelines there are - I really just want to be able to use the useIMask composition function without a shim, otherwise compilation fails.