### PR TITLE
fix: Allow forwarded refs in IMaskInput inputRef prop

### DIFF
--- a/packages/react-imask/src/mixin.ts
+++ b/packages/react-imask/src/mixin.ts
@@ -26,7 +26,7 @@ type ReactMaskProps<
   onComplete?: (value: Value, maskRef: IMask.InputMask<Opts>, e?: InputEvent) => void;
   unmask?: Unmask;
   value?: Value;
-  inputRef?: React.RefCallback<MaskElement>;
+  inputRef?: React.RefCallback<MaskElement> | React.ForwardedRef<MaskElement>;
   ref?: React.Ref<React.ComponentType<IMaskInputProps<Opts, Unmask, Value, MaskElement>>>;
 }
 


### PR DESCRIPTION
Extends the InputMask `inputRef` prop type to allow forwarded refs. Happy to also extend the IMaskMixin `inputRef` prop.

Fixes https://github.com/uNmAnNeR/imaskjs/issues/639