### PR TITLE
generate bundled, one file, esm build, too

### DIFF
--- a/packages/imask/rollup.config.js
+++ b/packages/imask/rollup.config.js
@@ -18,7 +18,7 @@ const commonPlugins = [
 ];
 
 export default [
-  ...[false, true].map(min => ({
+  ...[false, true].flatMap(min => ([{
     input: 'src/index.js',
     output: {
       file: `dist/imask${min ? '.min' : ''}.js`,
@@ -33,7 +33,18 @@ export default [
       polyfill(['./polyfills.js']),
       min && terser(),
     ],
-  })),
+  }, {
+    input: 'src/index.js',
+    output: {
+      format: 'esm',
+      file: `dist/imask.esm${min ? '.min' : ''}.js`,
+      sourcemap: true,
+    },
+    plugins: [
+      ...commonPlugins,
+      min && terser(),
+    ]
+  }])),
   {
     input: ['src/**/*.js'],
     output: {


### PR DESCRIPTION
I'm not sure if this is the right way, but my problem is the following: I'm using https://github.com/rails/importmap-rails to vendor js files by downloading them. It only downloads the file https://ga.jspm.io/npm:imask@6.4.3/esm/index.js which references other modules though, which are *not* downloaded and then 404. importmat-rails expects one file to contain everything, see for example https://github.com/rails/importmap-rails/issues/65.

I just amended the rollup config to create such a bundled esm file. It seems to work by my manual tests, so maybe you could see if everything if correct and generate this file when publishing the package?

In addition it would be nice to know if https://github.com/rails/importmap-rails can be made to automatically use it then (I assume it uses the `module:` entrypoint by default; is there maybe an entrypoint definition for "one module containing them all"?), but first I'd like to make sure the bundled esm is generated correctly.

WDYT?