### PR TITLE
Update readme.md - angular NgModule setup

### DIFF
--- a/packages/angular-imask/README.md
+++ b/packages/angular-imask/README.md
@@ -13,11 +13,11 @@ angular-imask
 
 ## Setup
 ```javascript
-import {IMaskDirective} from 'angular-imask';
+import {IMaskModule} from 'angular-imask';
 
 @NgModule({
   imports: [
-    IMaskDirective,
+    IMaskModule,
     ...
   ],
   ...


### PR DESCRIPTION
Importing the directive in NgModule as suggested generates this compiling error:  

"The directive 'IMaskDirective' appears in 'imports', but is not standalone and cannot be imported directly. It must be imported via an NgModule. IMaskDirective,
The build process had an error interrupting execution."

The import should be the IMaskModule