### PR TITLE
Fix ChangeDetails export

### DIFF
--- a/packages/imask/src/core/change-details.js
+++ b/packages/imask/src/core/change-details.js
@@ -1,6 +1,8 @@
 // @flow
 
 
+import IMask from "./holder";
+
 /**
   Provides details of changing model value
   @param {Object} [details]
@@ -55,3 +57,5 @@ class ChangeDetails {
     return this.tailShift + this.inserted.length;
   }
 }
+
+IMask.ChangeDetails = ChangeDetails;


### PR DESCRIPTION
In https://github.com/uNmAnNeR/imaskjs/commit/333eb9a12bafbc8871cb41ccaa4a9ebad1530999 `ChangeDetails` class was exported, but there is a missing part preventing from using it.