### PR TITLE
Use .cjs extension for UMD bundles so that they can be imported using require()

### DIFF
--- a/packages/imask/package.json
+++ b/packages/imask/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/uNmAnNeR/imaskjs/issues",
   "homepage": "https://imask.js.org/",
   "description": "vanilla javascript input mask",
-  "main": "dist/imask.js",
+  "main": "dist/imask.cjs",
   "module": "esm/index.js",
   "type": "module",
   "repository": "https://github.com/uNmAnNeR/imaskjs",
@@ -18,7 +18,7 @@
     ".": {
       "types": "./esm/index.d.ts",
       "import": "./esm/index.js",
-      "default": "./dist/imask.js"
+      "default": "./dist/imask.cjs"
     },
     "./holder": {
       "types": "./esm/imask.d.ts",

--- a/packages/imask/rollup.config.js
+++ b/packages/imask/rollup.config.js
@@ -17,14 +17,14 @@ const commonPlugins = [
     babelHelpers: 'runtime',
     include: input,
   }),
-]; 
+];
 
 export default [
   ...[false, true].map(min => ({
     input: 'src/index.ts',
     output: {
       name: 'IMask',
-      file: `dist/imask${min ? '.min' : ''}.js`,
+      file: `dist/imask${min ? '.min' : ''}.cjs`,
       format: 'umd',
       sourcemap: true,
       exports: 'named',

--- a/packages/react-imask/package.json
+++ b/packages/react-imask/package.json
@@ -5,7 +5,7 @@
   "author": "Alexey Kryazhev",
   "homepage": "https://imask.js.org/",
   "description": "React input mask",
-  "main": "dist/react-imask.js",
+  "main": "dist/react-imask.cjs",
   "module": "esm/index.js",
   "type": "module",
   "types": "index.d.ts",
@@ -14,7 +14,7 @@
     ".": {
       "types": "./esm/index.d.ts",
       "import": "./esm/index.js",
-      "default": "./dist/react-imask.js"
+      "default": "./dist/react-imask.cjs"
     },
     "./esm": {
       "types": "./esm/index.d.ts",

--- a/packages/react-native-imask/package.json
+++ b/packages/react-native-imask/package.json
@@ -5,14 +5,14 @@
   "version": "7.1.2",
   "homepage": "https://imask.js.org/",
   "description": "React Native Input Mask",
-  "main": "dist/react-native-imask.js",
+  "main": "dist/react-native-imask.cjs",
   "module": "esm/index.js",
   "type": "module",
   "repository": "https://github.com/uNmAnNeR/imaskjs/tree/master/packages/react-native-imask",
   "exports": {
     ".": {
       "import": "./esm/index.js",
-      "default": "./dist/react-native-imask.js"
+      "default": "./dist/react-native-imask.cjs"
     },
     "./*": "./*"
   },

--- a/packages/solid-imask/package.json
+++ b/packages/solid-imask/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "author": "Alexey Kryazhev",
   "description": "Solid input mask",
-  "main": "dist/solid-imask.js",
+  "main": "dist/solid-imask.cjs",
   "module": "esm/index.js",
   "types": "index.d.ts",
   "type": "module",
@@ -13,7 +13,7 @@
     ".": {
       "types": "./esm/index.d.ts",
       "import": "./esm/index.js",
-      "default": "./dist/solid-imask.js"
+      "default": "./dist/solid-imask.cjs"
     },
     "./esm": {
       "types": "./esm/index.d.ts",

--- a/packages/svelte-imask/package.json
+++ b/packages/svelte-imask/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "version": "7.1.2",
   "description": "Svelte input mask",
-  "main": "dist/svelte-imask.js",
+  "main": "dist/svelte-imask.cjs",
   "module": "esm/index.js",
   "type": "module",
   "types": "index.d.ts",
@@ -18,7 +18,7 @@
     ".": {
       "types": "./esm/index.d.ts",
       "import": "./esm/index.js",
-      "default": "./dist/svelte-imask.js"
+      "default": "./dist/svelte-imask.cjs"
     },
     "./esm": {
       "types": "./esm/index.d.ts",

--- a/packages/vue-imask/package.json
+++ b/packages/vue-imask/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "version": "7.1.2",
   "description": "Vue input mask",
-  "main": "dist/vue-imask.js",
+  "main": "dist/vue-imask.cjs",
   "module": "esm/index.js",
   "type": "module",
   "types": "index.d.ts",
@@ -18,7 +18,7 @@
     ".": {
       "types": "./esm/index.d.ts",
       "import": "./esm/index.js",
-      "default": "./dist/vue-imask.js"
+      "default": "./dist/vue-imask.cjs"
     },
     "./esm": {
       "types": "./esm/index.d.ts",


### PR DESCRIPTION
Packages are currently typed as "module" but emit ~CommonJS~ UMD builds without the .cjs extension. This prevents apps/bundlers from importing them using `require()`.

```
[ERR_REQUIRE_ESM]: require() of ES Module [rootpath]/node_modules/imask/dist/imask.js from [rootpath]/.next/server/chunks/4752.js not supported.
imask.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead rename imask.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in [rootpath]/node_modules/imask/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).
```