### PR TITLE
provide default typearg of InputMask

### DIFF
--- a/packages/imask/src/controls/input.ts
+++ b/packages/imask/src/controls/input.ts
@@ -16,7 +16,7 @@ type InputMaskEventListener = (e?: InputEvent) => void;
 
 /** Listens to element events and controls changes between element and {@link Masked} */
 export default
-class InputMask<Opts extends FactoryArg> {
+class InputMask<Opts extends FactoryArg = FactoryArg> {
   /**
     View element
   */


### PR DESCRIPTION
So we can just use `private _mask: InputMask;` instead of `private _mask: InputMask<FactoryArg>;`
I would guess that it is applicable to the majority of users.