### PR TITLE
fix: changed solid types path

### DIFF
--- a/packages/solid-imask/package.json
+++ b/packages/solid-imask/package.json
@@ -6,7 +6,7 @@
   "description": "Solid input mask",
   "main": "dist/solid-imask.js",
   "module": "esm/index.js",
-  "types": "index.d.ts",
+  "types": "esm/index.d.ts",
   "type": "module",
   "repository": "https://github.com/uNmAnNeR/imaskjs/tree/master/packages/solid-imask",
   "exports": {

--- a/packages/solid-imask/tsconfig.json
+++ b/packages/solid-imask/tsconfig.json
@@ -7,6 +7,6 @@
     "jsxImportSource": "solid-js",
     "declaration": true,
     "declarationMap": true,
-    "declarationDir": "./dist"
+    "declarationDir": "./esm"
   }
 }


### PR DESCRIPTION
According to the `package.json`, types should be located in `esm` folder:
``` json
"exports": {
  ".": {
    "types": "./esm/index.d.ts",
    "import": "./esm/index.js",
    "default": "./dist/solid-imask.js"
  },
}
```
But due to the settings in `tsconfig.json` they are generated in `dist` folder:
``` json
"compilerOptions": {
  "declarationDir": "./dist"
}
```
It throws an error:
```
Could not find a declaration file for module 'solid-imask'. 
'../node_modules/solid-imask/esm/index.js' implicitly has an 'any' type.
Try `npm i --save-dev @types/solid-imask` if it exists or 
add a new declaration (.d.ts) file containing `declare module 'solid-imask';`
```