### PR TITLE
Make parse/format required if custom pattern is used.

### DIFF
--- a/packages/imask/src/masked/date.ts
+++ b/packages/imask/src/masked/date.ts
@@ -20,15 +20,18 @@ type DateOptionsKeys =
 export
 type DateValue = Date | null;
 
+const DefaultPattern = 'd{.}`m{.}`Y'
+
+// Make format and parse required when pattern is provided
+type RequiredDateOptions = ({ pattern?: never |  typeof DefaultPattern; format?: MaskedDate["format"]; parse?: MaskedDate["parse"] } |
+  { pattern: MaskedDate["pattern"]; format: MaskedDate["format"]; parse: MaskedDate["parse"] })
+
 export
 type MaskedDateOptions =
   Omit<MaskedPatternOptions<DateValue>, 'mask'> &
   Partial<Pick<MaskedDate, DateOptionsKeys>> &
   { mask?: string | DateMaskType } &
-  // Make format and parse required when pattern is provided
-  ({ pattern?: never; format?: MaskedDate["format"]; parse?: MaskedDate["parse"] } |
-  { pattern: MaskedDate["pattern"]; format: MaskedDate["format"]; parse: MaskedDate["parse"] })
-;
+  RequiredDateOptions;
 
 /** Date mask */
 export default
@@ -55,7 +58,7 @@ class MaskedDate extends MaskedPattern<DateValue> {
   static DEFAULTS = {
     ...MaskedPattern.DEFAULTS,
     mask: Date,
-    pattern: 'd{.}`m{.}`Y',
+    pattern: DefaultPattern,
     format: (date: DateValue, masked: Masked): string => {
       if (!date) return '';
 
@@ -98,7 +101,7 @@ class MaskedDate extends MaskedPattern<DateValue> {
     }));
   }
 
-  override updateOptions (opts: Partial<MaskedDateOptions>) {
+  override updateOptions (opts: Partial<MaskedDateOptions> & RequiredDateOptions) {
     super.updateOptions(opts as Partial<MaskedPatternOptions<DateValue>>);
   }
 

--- a/packages/imask/src/masked/date.ts
+++ b/packages/imask/src/masked/date.ts
@@ -24,7 +24,10 @@ export
 type MaskedDateOptions =
   Omit<MaskedPatternOptions<DateValue>, 'mask'> &
   Partial<Pick<MaskedDate, DateOptionsKeys>> &
-  { mask?: string | DateMaskType }
+  { mask?: string | DateMaskType } &
+  // Make format and parse required when pattern is provided
+  ({ pattern?: never; format?: MaskedDate["format"]; parse?: MaskedDate["parse"] } |
+  { pattern: MaskedDate["pattern"]; format: MaskedDate["format"]; parse: MaskedDate["parse"] })
 ;
 
 /** Date mask */

--- a/packages/imask/test/masked/date.ts
+++ b/packages/imask/test/masked/date.ts
@@ -17,6 +17,7 @@ describe('MaskedDate', function () {
   describe('#isDateExist', function () {
     masked.updateOptions({
       pattern: MaskedDate.DEFAULTS.pattern + '.',
+      parse: MaskedDate.DEFAULTS.parse,
       lazy: false,
       format: function (date) {
         return MaskedDate.DEFAULTS.format(date, masked) + '.';


### PR DESCRIPTION
Hi, just wanted to contribute to your amazing repo!
This change fixes #973 

If the user provides the default pattern, the type check is ignored

Here's a screenshot of vscode showing the different cases, default pattern, custom pattern with error, custom parse without error and custom pattern with format and parse without error
![imagen](https://github.com/uNmAnNeR/imaskjs/assets/4268580/afc85701-4a40-4be8-a2f1-3483e5a456e8)
