### PR TITLE
fix #1050

### DIFF
--- a/packages/imask/package.json
+++ b/packages/imask/package.json
@@ -8,7 +8,6 @@
   "description": "vanilla javascript input mask",
   "main": "dist/imask.js",
   "module": "esm/index.js",
-  "type": "module",
   "repository": "https://github.com/uNmAnNeR/imaskjs",
   "types": "index.d.ts",
   "engines": {
@@ -18,7 +17,7 @@
     ".": {
       "types": "./esm/index.d.ts",
       "import": "./esm/index.js",
-      "require": "./dist/imask.cjs",
+      "require": "./dist/imask.js",
       "default": "./dist/imask.js"
     },
     "./holder": {
@@ -64,7 +63,7 @@
     }
   },
   "scripts": {
-    "test": "cross-env NODE_ENV=test c8 node --test-reporter=spec --loader tsx --test test/**/*",
+    "test": "cross-env NODE_ENV=test tsx --test test/**/*",
     "watch": "rollup -c -w",
     "lint": "eslint src",
     "prebuild": "npm run lint -- --quiet && rimraf --glob \"{dist,esm}\"",

--- a/packages/imask/rollup.config.mjs
+++ b/packages/imask/rollup.config.mjs
@@ -51,7 +51,7 @@ export default [
     output: {
       name: 'IMask',
       format: 'cjs',
-      file: 'dist/imask.cjs',
+      file: 'dist/imask.js',
       sourcemap: true,
       exports: 'named',
     },

--- a/packages/react-imask/package.json
+++ b/packages/react-imask/package.json
@@ -7,14 +7,13 @@
   "description": "React input mask",
   "main": "dist/react-imask.js",
   "module": "esm/index.js",
-  "type": "module",
   "types": "index.d.ts",
   "repository": "https://github.com/uNmAnNeR/imaskjs/tree/master/packages/react-imask",
   "exports": {
     ".": {
       "types": "./esm/index.d.ts",
       "import": "./esm/index.js",
-      "require": "./dist/react-imask.cjs",
+      "require": "./dist/react-imask.js",
       "default": "./dist/react-imask.js"
     },
     "./esm": {

--- a/packages/react-imask/rollup.config.mjs
+++ b/packages/react-imask/rollup.config.mjs
@@ -1,4 +1,3 @@
-// import withSolid from 'rollup-preset-solid';
 import { babel } from '@rollup/plugin-babel';
 import multi from 'rollup-plugin-multi-input';
 import replace from '@rollup/plugin-replace';
@@ -7,13 +6,15 @@ import commonjs from '@rollup/plugin-commonjs';
 import pkg from './package.json' with { type: 'json' };
 
 
+const input = ['src/**'];
+const extensions = ['.js', '.ts'];
+
 const globals = {
-  'solid-js': 'Solid',
+  react: 'React',
   imask: 'IMask',
+  'prop-types': 'PropTypes',
 };
 
-const extensions = ['.js', '.ts', '.tsx', '.jsx'];
-const input = ['src/**'];
 const commonPlugins = [
   nodeResolve({ extensions }),
   commonjs(),
@@ -22,7 +23,6 @@ const commonPlugins = [
     rootMode: 'upward',
     babelHelpers: 'runtime',
     include: input,
-    presets: [ 'solid' ],
   }),
 ];
 
@@ -32,7 +32,7 @@ export default [
     input: 'src/index.ts',
     external: Object.keys(globals),
     output: {
-      name: 'SolidIMask',
+      name: 'ReactIMask',
       file: pkg.main,
       globals,
       format: 'umd',
@@ -53,6 +53,7 @@ export default [
         "from 'imask'": "from 'imask/esm/imask'",
         "import 'imask'": "import 'imask/esm'",
         delimiters: ['', ''],
+        preventAssignment: true,
       }),
       multi.default(),
       ...commonPlugins,
@@ -62,13 +63,13 @@ export default [
     input: 'src/index.ts',
     external: Object.keys(globals),
     output: {
-      name: 'SolidIMask',
-      file: 'dist/solid-imask.cjs',
-      globals,
+      name: 'ReactIMask',
+      file: 'dist/react-imask.js',
       format: 'cjs',
+      globals,
       sourcemap: true,
       interop: 'auto',
     },
     plugins: commonPlugins,
   },
-];
+]

--- a/packages/react-native-imask/package.json
+++ b/packages/react-native-imask/package.json
@@ -7,12 +7,11 @@
   "description": "React Native Input Mask",
   "main": "dist/react-native-imask.js",
   "module": "esm/index.js",
-  "type": "module",
   "repository": "https://github.com/uNmAnNeR/imaskjs/tree/master/packages/react-native-imask",
   "exports": {
     ".": {
       "import": "./esm/index.js",
-      "require": "./dist/react-native-imask.cjs",
+      "require": "./dist/react-native-imask.js",
       "default": "./dist/react-native-imask.js"
     },
     "./*": "./*"

--- a/packages/react-native-imask/rollup.config.mjs
+++ b/packages/react-native-imask/rollup.config.mjs
@@ -56,7 +56,7 @@ export default [
     external: Object.keys(globals),
     output: {
       name: 'ReactNativeIMask',
-      file: 'dist/react-native-imask.cjs',
+      file: 'dist/react-native-imask.js',
       globals,
       format: 'cjs',
       sourcemap: true,

--- a/packages/solid-imask/package.json
+++ b/packages/solid-imask/package.json
@@ -7,13 +7,12 @@
   "main": "dist/solid-imask.js",
   "module": "esm/index.js",
   "types": "esm/index.d.ts",
-  "type": "module",
   "repository": "https://github.com/uNmAnNeR/imaskjs/tree/master/packages/solid-imask",
   "exports": {
     ".": {
       "types": "./esm/index.d.ts",
       "import": "./esm/index.js",
-      "require": "./dist/solid-imask.cjs",
+      "require": "./dist/solid-imask.js",
       "default": "./dist/solid-imask.js"
     },
     "./esm": {

--- a/packages/solid-imask/rollup.config.mjs
+++ b/packages/solid-imask/rollup.config.mjs
@@ -1,3 +1,4 @@
+// import withSolid from 'rollup-preset-solid';
 import { babel } from '@rollup/plugin-babel';
 import multi from 'rollup-plugin-multi-input';
 import replace from '@rollup/plugin-replace';
@@ -7,9 +8,11 @@ import pkg from './package.json' with { type: 'json' };
 
 
 const globals = {
-  imask: 'IMask'
+  'solid-js': 'Solid',
+  imask: 'IMask',
 };
-const extensions = ['.js', '.ts'];
+
+const extensions = ['.js', '.ts', '.tsx', '.jsx'];
 const input = ['src/**'];
 const commonPlugins = [
   nodeResolve({ extensions }),
@@ -19,19 +22,21 @@ const commonPlugins = [
     rootMode: 'upward',
     babelHelpers: 'runtime',
     include: input,
+    presets: [ 'solid' ],
   }),
 ];
+
 
 export default [
   {
     input: 'src/index.ts',
     external: Object.keys(globals),
     output: {
-      name: 'SvelteIMask',
+      name: 'SolidIMask',
       file: pkg.main,
+      globals,
       format: 'umd',
       sourcemap: true,
-      globals,
       interop: 'auto',
     },
     plugins: commonPlugins,
@@ -45,7 +50,7 @@ export default [
     },
     plugins: [
       replace({
-        "import IMask from 'imask'": "import IMask from 'imask/esm/imask'",
+        "from 'imask'": "from 'imask/esm/imask'",
         "import 'imask'": "import 'imask/esm'",
         delimiters: ['', ''],
       }),
@@ -57,13 +62,13 @@ export default [
     input: 'src/index.ts',
     external: Object.keys(globals),
     output: {
-      name: 'SvelteIMask',
-      file: 'dist/svelte-imask.cjs',
+      name: 'SolidIMask',
+      file: 'dist/solid-imask.js',
+      globals,
       format: 'cjs',
       sourcemap: true,
-      globals,
       interop: 'auto',
     },
     plugins: commonPlugins,
   },
-]
+];

--- a/packages/svelte-imask/package.json
+++ b/packages/svelte-imask/package.json
@@ -6,7 +6,6 @@
   "description": "Svelte input mask",
   "main": "dist/svelte-imask.js",
   "module": "esm/index.js",
-  "type": "module",
   "types": "index.d.ts",
   "repository": "https://github.com/uNmAnNeR/imaskjs/tree/master/packages/svelte-imask",
   "scripts": {
@@ -18,7 +17,7 @@
     ".": {
       "types": "./esm/index.d.ts",
       "import": "./esm/index.js",
-      "require": "./dist/svelte-imask.cjs",
+      "require": "./dist/svelte-imask.js",
       "default": "./dist/svelte-imask.js"
     },
     "./esm": {

--- a/packages/svelte-imask/rollup.config.mjs
+++ b/packages/svelte-imask/rollup.config.mjs
@@ -7,12 +7,8 @@ import pkg from './package.json' with { type: 'json' };
 
 
 const globals = {
-  imask: 'IMask',
-  vue: 'Vue',
-  'vue-demi': 'VueDemi',
-  '@vue/composition-api': 'vueCompositionApi',
+  imask: 'IMask'
 };
-
 const extensions = ['.js', '.ts'];
 const input = ['src/**'];
 const commonPlugins = [
@@ -26,13 +22,12 @@ const commonPlugins = [
   }),
 ];
 
-
 export default [
   {
     input: 'src/index.ts',
     external: Object.keys(globals),
     output: {
-      name: 'VueIMask',
+      name: 'SvelteIMask',
       file: pkg.main,
       format: 'umd',
       sourcemap: true,
@@ -50,7 +45,7 @@ export default [
     },
     plugins: [
       replace({
-        "from 'imask'": "from 'imask/esm/imask'",
+        "import IMask from 'imask'": "import IMask from 'imask/esm/imask'",
         "import 'imask'": "import 'imask/esm'",
         delimiters: ['', ''],
       }),
@@ -62,8 +57,8 @@ export default [
     input: 'src/index.ts',
     external: Object.keys(globals),
     output: {
-      name: 'VueIMask',
-      file: 'dist/vue-imask.cjs',
+      name: 'SvelteIMask',
+      file: 'dist/svelte-imask.js',
       format: 'cjs',
       sourcemap: true,
       globals,
@@ -71,4 +66,4 @@ export default [
     },
     plugins: commonPlugins,
   },
-];
+]

--- a/packages/vue-imask/package.json
+++ b/packages/vue-imask/package.json
@@ -6,7 +6,6 @@
   "description": "Vue input mask",
   "main": "dist/vue-imask.js",
   "module": "esm/index.js",
-  "type": "module",
   "types": "index.d.ts",
   "repository": "https://github.com/uNmAnNeR/imaskjs/tree/master/packages/vue-imask",
   "contributors": [
@@ -18,7 +17,7 @@
     ".": {
       "types": "./esm/index.d.ts",
       "import": "./esm/index.js",
-      "require": "./dist/vue-imask.cjs",
+      "require": "./dist/vue-imask.js",
       "default": "./dist/vue-imask.js"
     },
     "./esm": {

--- a/packages/vue-imask/rollup.config.mjs
+++ b/packages/vue-imask/rollup.config.mjs
@@ -6,15 +6,15 @@ import commonjs from '@rollup/plugin-commonjs';
 import pkg from './package.json' with { type: 'json' };
 
 
-const input = ['src/**'];
-const extensions = ['.js', '.ts'];
-
 const globals = {
-  react: 'React',
   imask: 'IMask',
-  'prop-types': 'PropTypes',
+  vue: 'Vue',
+  'vue-demi': 'VueDemi',
+  '@vue/composition-api': 'vueCompositionApi',
 };
 
+const extensions = ['.js', '.ts'];
+const input = ['src/**'];
 const commonPlugins = [
   nodeResolve({ extensions }),
   commonjs(),
@@ -32,11 +32,11 @@ export default [
     input: 'src/index.ts',
     external: Object.keys(globals),
     output: {
-      name: 'ReactIMask',
+      name: 'VueIMask',
       file: pkg.main,
-      globals,
       format: 'umd',
       sourcemap: true,
+      globals,
       interop: 'auto',
     },
     plugins: commonPlugins,
@@ -53,7 +53,6 @@ export default [
         "from 'imask'": "from 'imask/esm/imask'",
         "import 'imask'": "import 'imask/esm'",
         delimiters: ['', ''],
-        preventAssignment: true,
       }),
       multi.default(),
       ...commonPlugins,
@@ -63,13 +62,13 @@ export default [
     input: 'src/index.ts',
     external: Object.keys(globals),
     output: {
-      name: 'ReactIMask',
-      file: 'dist/react-imask.cjs',
+      name: 'VueIMask',
+      file: 'dist/vue-imask.js',
       format: 'cjs',
-      globals,
       sourcemap: true,
+      globals,
       interop: 'auto',
     },
     plugins: commonPlugins,
   },
-]
+];


### PR DESCRIPTION
Related issue: #1050 

## Summary of the changes

- Removed the `type="module"` key from the package's `package.json` files
   👆 _This is the primary change that resolved the issue. The following changes were downstream of this change. Once this change was made the import worked again as expected:_
    <img width="1142" alt="Screenshot 2024-10-12 at 9 13 27 PM" src="https://github.com/user-attachments/assets/faa1a272-df5c-47d1-9748-04248081b975">
- Renamed the package's `lib/*.cjs` file to `lib/*.js`.
   👆 _The use of the `.cjs` extension is no longer required because the module type is no longer explicitly defined. Consumer's bundlers will be able to resolve both the es and cjs modules appropriately with standard `.js` extensions now._
- Renamed the package's `rollup.config.js` files to `rollup.config.mjs`
   👆 _Because the module type is longer explicitly defined, CommonJS is the default node environment for each package. This means that we need a `.mjs` to use es modules in all of the local node scripts._
- Removed the `c8 node --test-reporter=spec --loader` part of the core test script
   🚨 _I was unable to get the existing tests to work with the current configuration/setup and the aforementioned changes. I found the the `tsx` command worked fine on its own. However, there was some issue loading `tsx` through node that was preventing it from resolving the modules properly. I looked into it and it turns out that [`--loader` option is actually experimental and may be removed](https://nodejs.org/api/cli.html#--experimental-loadermodule). In fact, there is an existing warning about it in the console when the tests are run:_
    <img width="1545" alt="Screenshot 2024-10-12 at 9 08 15 PM" src="https://github.com/user-attachments/assets/cd657dcc-8a26-4a2c-bf6f-a7acf388b124">
    _Obviously, I do not expect you to accept these updates without code coverage of your tests. However, I think this might be a good opportunity to resolve both issues (removal of `--loader` and `type="module"`). I am confident that an alternative methods or tool would work. FWIW, I have had great success with Jest and Vitest. If it would be helpful, I'd even be willing to do some of the footwork._