### PR TITLE
.off() typing fix

### DIFF
--- a/packages/imask/src/controls/input.ts
+++ b/packages/imask/src/controls/input.ts
@@ -308,7 +308,7 @@ class InputMask<Opts extends FactoryArg=Record<string, unknown>> {
   }
 
   /** Removes custom event listener */
-  off (ev: string, handler: InputMaskEventListener): this {
+  off (ev: string, handler?: InputMaskEventListener): this {
     if (!this._listeners[ev]) return this;
     if (!handler) {
       delete this._listeners[ev];


### PR DESCRIPTION
According to documentation and implementation the second parameter is optional. But in TS types it is required.